### PR TITLE
Stagger places with same lat/lng

### DIFF
--- a/app/routes/cities/city.js
+++ b/app/routes/cities/city.js
@@ -34,6 +34,33 @@ export default Ember.Route.extend({
   },
 
   afterModel(model) {
+
+    /*
+     * Find places that have identical lat/lng
+     */
+    const locations = {};
+    const radius = .00005;
+
+    model.places.forEach(place => {
+      const location = `${place.get('latitude')}-${place.get('longitude')}`;
+      locations[location] = locations[location] || [];
+      locations[location].push(place);
+    });
+
+    // Displace these locations by a small amount so they don't entirely overlap
+    Object.values(locations)
+      .filter(location => location.length > 1)
+      .forEach(location => {
+        location.forEach((place, i) => {
+          const radian = i * (Math.PI / ((location.length - 1) / 2));
+          const adjustedLat = place.get('latitude') + (Math.sin(radian) * radius);
+          const adjustedLng = place.get('longitude') + (Math.cos(radian) * radius);
+          
+          place.set('latitude', adjustedLat);
+          place.set('longitude', adjustedLng);
+        });
+      });
+
     let currentCity = this.get('currentCity');
     currentCity.setCity(model.city);
     currentCity.setAllInvestments(model.investments)


### PR DESCRIPTION
Places with same lat/lng now create a small circle around the original location instead of directly overlapping each other, hiding all places that lay below the most recently rendered icon. 